### PR TITLE
Fix FVPLUS-SET-BOOT-002: SETUP_ASSISTANT_TEMPLATE_FALLBACK_BY_TYPE is not defined

### DIFF
--- a/src/folderview.plus/usr/local/emhttp/plugins/folderview.plus/scripts/folderviewplus.wizard.js
+++ b/src/folderview.plus/usr/local/emhttp/plugins/folderview.plus/scripts/folderviewplus.wizard.js
@@ -707,6 +707,11 @@ const resolveSetupAssistantTemplateBestMatch = (...args) => getWizardSmartDetect
 const resolveSetupAssistantSmartBlueprintIndexes = (...args) => getWizardSmartDetectApi().resolveSetupAssistantSmartBlueprintIndexes(...args);
 const buildSetupAssistantTemplateAssignmentPreview = (...args) => getWizardSmartDetectApi().buildSetupAssistantTemplateAssignmentPreview(...args);
 
+const SETUP_ASSISTANT_TEMPLATE_FALLBACK_BY_TYPE = Object.freeze({
+    docker: String((window.FolderViewPlusSmartDetectConfig || {}).fallbackByType?.docker || 'Utilities'),
+    vm: String((window.FolderViewPlusSmartDetectConfig || {}).fallbackByType?.vm || 'Utility VMs')
+});
+
 const buildSetupAssistantTemplatePlanForType = (type) => {
     const resolvedType = normalizeManagedType(type);
     const bootstrap = getSetupAssistantTemplateBootstrap(resolvedType);


### PR DESCRIPTION
wizard.js references SETUP_ASSISTANT_TEMPLATE_FALLBACK_BY_TYPE on line 722, but this constant is only defined as a local variable inside wizard-smart-detect.js createApi() scope — not accessible from wizard.js. This causes a ReferenceError during Settings bootstrap when switching to basic mode, resulting in fatal error FVPLUS-SET-BOOT-002.

Fix: Define the constant in wizard.js using the same window.FolderViewPlusSmartDetectConfig source and default fallback values that wizard-smart-detect.js uses.

Summary

• What changed: Added SETUP_ASSISTANT_TEMPLATE_FALLBACK_BY_TYPE constant definition in folderviewplus.wizard.js (5 lines)
• Why: The constant was only scoped inside createApi() in wizard-smart-detect.js but referenced globally in wizard.js, causing a fatal bootstrap error on fresh installs

Validation

• [x] Static analysis — variable is now defined in the scope where it's used
• [x] Matches the same source (window.FolderViewPlusSmartDetectConfig) and defaults (Utilities / Utility VMs) as wizard-smart-detect.js
• [x] Local testing on Unraid 7.2.4, FolderView Plus 2026.03.23.33 (ok)

Notes

• No migration needed — this is a missing definition, not a behavioral change
• The fix is idempotent: if FolderViewPlusSmartDetectConfig is loaded, its values are used; otherwise the same defaults apply