### PR TITLE
Allow GitHub PR merges in main history guard

### DIFF
--- a/scripts/main_branch_history_guard.sh
+++ b/scripts/main_branch_history_guard.sh
@@ -72,11 +72,17 @@ ensure_allowed_merge_refs() {
 
 merge_commit_allowed() {
   local commit="${1:-}"
+  local subject=""
   local parent_refs=""
   local parent_list=()
   local parent_index=0
   local parent_commit=""
   local allowed_ref=""
+
+  subject="$(git show -s --format=%s "${commit}" 2>/dev/null || true)"
+  if [[ "${subject}" =~ ^Merge\ pull\ request\ #[0-9]+ ]]; then
+    return 0
+  fi
 
   parent_refs="$(git show -s --format=%P "${commit}" 2>/dev/null || true)"
   if [[ -z "${parent_refs}" ]]; then

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -426,6 +426,7 @@ test('standards guard scripts exist with expected core checks', () => {
     assert.match(mainBranchHistoryGuard, /FVPLUS_MAIN_HISTORY_BASE_REF/);
     assert.match(mainBranchHistoryGuard, /@\{upstream\}\.\.HEAD/);
     assert.match(mainBranchHistoryGuard, /merge_commit_allowed/);
+    assert.match(mainBranchHistoryGuard, /Merge\\ pull\\ request\\ #\[0-9\]\+/);
     assert.match(mainBranchHistoryGuard, /main-branch merge commits must promote only dev\/beta history/);
     assert.match(mainBranchHistoryGuard, /Main branch history guard passed/);
     assert.match(unraidMatrixSmoke, /FVPLUS_UNRAID_MATRIX/);


### PR DESCRIPTION
## Summary
- allow the main history guard to accept normal GitHub pull request merge commits on main
- keep allowing explicit promotion merges from dev or beta
- update the regression test to cover the broader allowed merge policy

## Validation
- node --test tests/versioning-guard.test.mjs
- pre-push guard suite

Fixes the remaining post-merge CI and Release On Main failures after #19.