### PR TITLE
Allow validated stable release merge subjects

### DIFF
--- a/scripts/main_branch_history_guard.sh
+++ b/scripts/main_branch_history_guard.sh
@@ -74,10 +74,14 @@ merge_commit_allowed() {
   local parent_index=0
   local parent_commit=""
   local allowed_ref=""
+  local stable_release_pr=0
 
   subject="$(git show -s --format=%s "${commit}" 2>/dev/null || true)"
   if [[ "${subject}" =~ ^Merge\ pull\ request\ #[0-9]+ ]]; then
     return 0
+  fi
+  if [[ "${subject}" =~ ^Stable\ release\ [0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2,}\ \(#[0-9]+\)$ ]]; then
+    stable_release_pr=1
   fi
 
   parent_refs="$(git show -s --format=%P "${commit}" 2>/dev/null || true)"
@@ -94,6 +98,12 @@ merge_commit_allowed() {
         continue
       fi
       if git merge-base --is-ancestor "${parent_commit}" "${allowed_ref}"; then
+        return 0
+      fi
+      # A stable release PR adds the main-channel package commit after merging
+      # dev. Accept that release tip only when it still contains current dev.
+      if [[ "${stable_release_pr}" -eq 1 ]] \
+        && git merge-base --is-ancestor "${allowed_ref}" "${parent_commit}"; then
         return 0
       fi
     done

--- a/scripts/prepare_backmerge_dev_package.sh
+++ b/scripts/prepare_backmerge_dev_package.sh
@@ -43,5 +43,7 @@ if [[ ! -f "${notes_path}" ]]; then
   } > "${notes_path}"
 fi
 
-FVPLUS_REQUIRE_EXPLICIT_RELEASE_NOTES=1 bash pkg_build.sh --branch dev
+FVPLUS_EXPECT_PLUGIN_BRANCH=dev \
+FVPLUS_REQUIRE_EXPLICIT_RELEASE_NOTES=1 \
+bash pkg_build.sh --branch dev
 echo "Prepared back-merge dev package ${version}."

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -51,6 +51,7 @@ const releaseNoteCategoryContractPath = path.join(repoRoot, 'src/folderview.plus
 const doctorPath = path.join(repoRoot, 'scripts/doctor.sh');
 const sharedLibPath = path.join(repoRoot, 'scripts/lib.sh');
 const syncMainToDevPath = path.join(repoRoot, 'scripts/sync_main_to_dev.sh');
+const prepareBackmergeDevPackagePath = path.join(repoRoot, 'scripts/prepare_backmerge_dev_package.sh');
 const prePushHookPath = path.join(repoRoot, '.githooks/pre-push');
 const perfBaselinePath = path.join(repoRoot, 'scripts/perf_baseline.json');
 const jsUnusedSymbolsGuardPath = path.join(repoRoot, 'scripts/js_unused_symbols_guard.mjs');
@@ -64,6 +65,7 @@ const stableTemplate = fs.readFileSync(stableTemplatePath, 'utf8');
 const releaseGuard = fs.readFileSync(releaseGuardPath, 'utf8');
 const devFinalize = fs.readFileSync(devFinalizePath, 'utf8');
 const releasePrepare = fs.readFileSync(releasePreparePath, 'utf8');
+const prepareBackmergeDevPackage = fs.readFileSync(prepareBackmergeDevPackagePath, 'utf8');
 const simulateMainRelease = fs.readFileSync(simulateMainReleasePath, 'utf8');
 const ciWorkflow = fs.readFileSync(ciWorkflowPath, 'utf8');
 const backmergeWorkflow = fs.readFileSync(backmergeWorkflowPath, 'utf8');
@@ -554,6 +556,7 @@ test('validation workflows delegate to the shared ci suite with dev coverage, fa
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
     assert.match(backmergeWorkflow, /FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/);
     assert.match(backmergeWorkflow, /bash scripts\/prepare_backmerge_dev_package\.sh/);
+    assert.match(prepareBackmergeDevPackage, /FVPLUS_EXPECT_PLUGIN_BRANCH=dev[\s\S]*bash pkg_build\.sh --branch dev/);
     assert.doesNotMatch(backmergeWorkflow, /FVPLUS_ALLOW_PACKAGED_SOURCE_DRIFT:\s*'1'/);
     assert.match(backmergeWorkflow, /bash scripts\/run_ci_suite\.sh/);
     assert.match(backmergeWorkflow, /Setup CI environment/);

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -899,6 +899,8 @@ test('standards guard scripts exist with expected core checks', () => {
     assert.match(mainBranchHistoryGuard, /@\{upstream\}\.\.HEAD/);
     assert.match(mainBranchHistoryGuard, /merge_commit_allowed/);
     assert.match(mainBranchHistoryGuard, /Merge\\ pull\\ request\\ #\[0-9\]\+/);
+    assert.ok(mainBranchHistoryGuard.includes('^Stable\\ release\\ [0-9]{4}'));
+    assert.match(mainBranchHistoryGuard, /git merge-base --is-ancestor "\$\{allowed_ref\}" "\$\{parent_commit\}"/);
     assert.match(mainBranchHistoryGuard, /main-branch merge commits must promote only dev history/);
     assert.match(mainBranchHistoryGuard, /Main branch history guard passed/);
     assert.match(unraidMatrixSmoke, /FVPLUS_UNRAID_MATRIX/);


### PR DESCRIPTION
## Summary

- Recognize the versioned stable-release PR subject used by release PR #58.
- Accept that subject only when the merged release tip contains the current `dev` history.
- Preserve rejection of unrelated merge commits.
- Add versioning-guard source contracts for the stable subject and reverse ancestry check.

## Root cause

The stable release merge used subject `Stable release 2026.08.11.15 (#58)` instead of GitHub's default `Merge pull request #58 ...`. The main history guard only recognized the default subject or a merged parent already contained by `dev`, so Release On Main stopped after all preceding validation passed.

## Validation

- `bash -n scripts/main_branch_history_guard.sh`
- `shellcheck -x --source-path=SCRIPTDIR scripts/main_branch_history_guard.sh`
- `node --test tests/versioning-guard.test.mjs` — 41/41 passed
- `bash scripts/run_ci_suite.sh --lane lint --lane workflow-tests --lane workflow-guards` — passed; 45/45 workflow/support tests
- Direct proof: release parent `d8db5c6c...` contains `origin/dev`