### PR TITLE
Install back-merge validation dependencies

### DIFF
--- a/.github/workflows/backmerge-main-to-dev.yml
+++ b/.github/workflows/backmerge-main-to-dev.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Setup CI environment
         uses: ./.github/actions/setup-ci-env
 
+      - name: Install Node validation dependencies
+        run: npm ci --ignore-scripts
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"

--- a/scripts/workflow_self_check.sh
+++ b/scripts/workflow_self_check.sh
@@ -221,6 +221,9 @@ if (!/upload-artifact@[0-9a-f]{40}\s+# v7/.test(backmergeWorkflow)) {
 if (!/FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must validate merged dev state with FVPLUS_EXPECT_PLUGIN_BRANCH set to dev.');
 }
+if (!/Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/.test(backmergeWorkflow)) {
+  fail('Back-merge workflow must install locked Node validation dependencies before running the full suite.');
+}
 if (!/bash scripts\/prepare_backmerge_dev_package\.sh/.test(backmergeWorkflow) ||
     /FVPLUS_ALLOW_PACKAGED_SOURCE_DRIFT:\s*'1'/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must package merged source instead of bypassing packaged/source drift validation.');

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -554,6 +554,7 @@ test('validation workflows delegate to the shared ci suite with dev coverage, fa
     assert.match(releaseOnMainWorkflow, /bash scripts\/run_ci_suite\.sh --release/);
 
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
+    assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/);
     assert.match(backmergeWorkflow, /bash scripts\/prepare_backmerge_dev_package\.sh/);
     assert.match(prepareBackmergeDevPackage, /FVPLUS_EXPECT_PLUGIN_BRANCH=dev[\s\S]*bash pkg_build\.sh --branch dev/);
@@ -694,6 +695,7 @@ test('release-on-main workflow auto-publishes validated releases from current pl
 test('back-merge workflow validates merged dev state before pushing', () => {
     assert.match(backmergeWorkflow, /name:\s*Back-Merge Main To Dev/);
     assert.match(backmergeWorkflow, /Setup CI environment/);
+    assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /Sync main into dev/);
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
     assert.match(backmergeWorkflow, /Push back-merge branch when updated/);


### PR DESCRIPTION
## Summary
- install locked Node validation dependencies in the main-to-dev back-merge workflow
- add workflow contracts so the dependency install cannot be removed unnoticed

## Root cause
The full back-merge validation suite imports declared npm packages such as `opencc-js`, but this workflow restored only npm caches and never ran `npm ci`. Run 31553370083 therefore failed with `ERR_MODULE_NOT_FOUND` despite the package being declared and locked.

## Validation
- `node --test tests/versioning-guard.test.mjs` (41 passed)
- `bash scripts/workflow_self_check.sh`
- `bash scripts/run_ci_suite.sh --lane workflow-tests --lane workflow-guards` (45 passed; Actionlint and workflow guards passed)
- `git diff --check`