### PR TITLE
Commit rebuilt back-merge package

### DIFF
--- a/.github/workflows/backmerge-main-to-dev.yml
+++ b/.github/workflows/backmerge-main-to-dev.yml
@@ -48,6 +48,15 @@ jobs:
           chmod +x scripts/prepare_backmerge_dev_package.sh
           bash scripts/prepare_backmerge_dev_package.sh
 
+      - name: Commit synchronized dev package
+        run: |
+          git add --all
+          if git diff --cached --quiet; then
+            echo "No dev package changes to commit."
+          else
+            git commit --no-verify -m "Rebuild dev package after main sync"
+          fi
+
       - name: Validate merged dev state before push
         env:
           FVPLUS_EXPECT_PLUGIN_BRANCH: 'dev'

--- a/scripts/workflow_self_check.sh
+++ b/scripts/workflow_self_check.sh
@@ -224,6 +224,9 @@ if (!/FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/.test(backmergeWorkflow)) {
 if (!/Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must install locked Node validation dependencies before running the full suite.');
 }
+if (!/Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/.test(backmergeWorkflow)) {
+  fail('Back-merge workflow must commit the rebuilt dev package before validation and push.');
+}
 if (!/bash scripts\/prepare_backmerge_dev_package\.sh/.test(backmergeWorkflow) ||
     /FVPLUS_ALLOW_PACKAGED_SOURCE_DRIFT:\s*'1'/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must package merged source instead of bypassing packaged/source drift validation.');

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -557,6 +557,7 @@ test('validation workflows delegate to the shared ci suite with dev coverage, fa
     assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/);
     assert.match(backmergeWorkflow, /bash scripts\/prepare_backmerge_dev_package\.sh/);
+    assert.match(backmergeWorkflow, /Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/);
     assert.match(prepareBackmergeDevPackage, /FVPLUS_EXPECT_PLUGIN_BRANCH=dev[\s\S]*bash pkg_build\.sh --branch dev/);
     assert.doesNotMatch(backmergeWorkflow, /FVPLUS_ALLOW_PACKAGED_SOURCE_DRIFT:\s*'1'/);
     assert.match(backmergeWorkflow, /bash scripts\/run_ci_suite\.sh/);
@@ -697,6 +698,7 @@ test('back-merge workflow validates merged dev state before pushing', () => {
     assert.match(backmergeWorkflow, /Setup CI environment/);
     assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /Sync main into dev/);
+    assert.match(backmergeWorkflow, /Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/);
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
     assert.match(backmergeWorkflow, /Push back-merge branch when updated/);
     assert.match(backmergeWorkflow, /Create or update back-merge PR/);


### PR DESCRIPTION
## Summary
- commit the rebuilt dev package before back-merge validation and branch publication
- guard the package commit step in workflow contracts

## Root cause
The back-merge workflow rebuilt and validated dev artifacts in its working tree, but `git rev-parse dev` still referenced the earlier merge commit. The pushed PR therefore omitted the validated manifest/archive/SBOM updates and produced a stale SBOM in PR context.

## Validation
- `node --test tests/versioning-guard.test.mjs` (41 passed)
- `bash scripts/workflow_self_check.sh`
- `bash scripts/run_ci_suite.sh --lane workflow-tests --lane workflow-guards` (45 passed; Actionlint and workflow guards passed)
- `git diff --check`