### PR TITLE
Acknowledge Unraid API v4.37.3 compatibility

### DIFF
--- a/docs/unraid-docker-interface-compatibility.md
+++ b/docs/unraid-docker-interface-compatibility.md
@@ -2,7 +2,7 @@
 
 This document defines how FolderView Plus coexists with the current table-based Unraid Docker page and the native component/API replacement being developed by Unraid.
 
-The upstream implementation was last reviewed on 2026-08-21 against Unraid API v4.37.2. That release adds TXZ-install cleanup for stale Unraid API web-component files without changing the Docker interface, generated Docker GraphQL contract, native Docker page, or organizer implementation. The generated Docker contract retained the reviewed signature, and Unraid's [`docker-containers-page` file modification](https://github.com/unraid/api/blob/main/api/src/unraid-api/unraid-file-modifier/modifications/docker-containers-page.modification.ts) still returned `shouldApply: false`, while its replacement markup contained `<unraid-docker-container-overview>`. The native Docker implementation therefore remains prerelease, and safe mode plus the existing organizer boundary remain unchanged.
+The upstream implementation was last reviewed on 2026-08-27 against Unraid API v4.37.3. That release serializes concurrent Connect-triggered nginx reload requests without changing the Docker interface, generated Docker GraphQL contract, native Docker page, or organizer implementation. The generated Docker contract retained the reviewed signature, and Unraid's [`docker-containers-page` file modification](https://github.com/unraid/api/blob/main/api/src/unraid-api/unraid-file-modifier/modifications/docker-containers-page.modification.ts) still returned `shouldApply: false`, while its replacement markup contained `<unraid-docker-container-overview>`. The native Docker implementation therefore remains prerelease, and safe mode plus the existing organizer boundary remain unchanged.
 
 ## Host generations
 

--- a/docs/unraid-docker-upstream-baseline.json
+++ b/docs/unraid-docker-upstream-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-21",
-  "latestReviewedApiRelease": "v4.37.2",
+  "reviewedAt": "2026-08-27",
+  "latestReviewedApiRelease": "v4.37.3",
   "schemaSignature": "dc036a1ef8b075d8f193831554cb93c0b2bbce6e1bffb45752841ffaa2aa6d0f",
   "requiredTokens": [
     "containers(skipCache: Boolean! = false @deprecated(reason: \"Caching has been removed; this parameter is now ignored\")): [DockerContainer!]!",


### PR DESCRIPTION
Updates the reviewed upstream compatibility baseline from Unraid API v4.37.2 to v4.37.3. The reviewed release only serializes concurrent Connect-triggered nginx reload requests; the Docker GraphQL schema signature, native Docker page gate, and FolderView Plus compatibility behavior remain unchanged. No plugin runtime, package, version, or release metadata changes are included. Resolves #84 after the main compatibility monitor confirms the reviewed baseline.