### PR TITLE
Fix back-merge dependency installation order

### DIFF
--- a/.github/workflows/backmerge-main-to-dev.yml
+++ b/.github/workflows/backmerge-main-to-dev.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Setup CI environment
         uses: ./.github/actions/setup-ci-env
 
-      - name: Install Node validation dependencies
-        run: npm ci --ignore-scripts
-
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -42,6 +39,9 @@ jobs:
       - name: Sync main into dev
         run: |
           bash scripts/sync_main_to_dev.sh
+
+      - name: Install merged dev validation dependencies
+        run: npm ci --ignore-scripts
 
       - name: Rebuild synchronized dev package
         run: |

--- a/scripts/workflow_self_check.sh
+++ b/scripts/workflow_self_check.sh
@@ -247,8 +247,8 @@ if (!/upload-artifact@[0-9a-f]{40}\s+# v7/.test(backmergeWorkflow)) {
 if (!/FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must validate merged dev state with FVPLUS_EXPECT_PLUGIN_BRANCH set to dev.');
 }
-if (!/Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/.test(backmergeWorkflow)) {
-  fail('Back-merge workflow must install locked Node validation dependencies before running the full suite.');
+if (!/Sync main into dev[\s\S]*Install merged dev validation dependencies[\s\S]*npm ci --ignore-scripts/.test(backmergeWorkflow)) {
+  fail('Back-merge workflow must install locked Node validation dependencies from the merged dev tree before packaging and validation.');
 }
 if (!/Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/.test(backmergeWorkflow)) {
   fail('Back-merge workflow must commit the rebuilt dev package before validation and push.');

--- a/tests/versioning-guard.test.mjs
+++ b/tests/versioning-guard.test.mjs
@@ -500,7 +500,7 @@ test('validation workflows delegate to the shared ci suite with dev coverage, fa
     assert.match(releaseOnMainWorkflow, /bash scripts\/run_ci_suite\.sh --release/);
 
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
-    assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
+    assert.match(backmergeWorkflow, /Sync main into dev[\s\S]*Install merged dev validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /FVPLUS_EXPECT_PLUGIN_BRANCH:\s*'dev'/);
     assert.match(backmergeWorkflow, /bash scripts\/prepare_backmerge_dev_package\.sh/);
     assert.match(backmergeWorkflow, /Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/);
@@ -652,8 +652,7 @@ test('release-on-main workflow auto-publishes validated releases from current pl
 test('back-merge workflow validates merged dev state before pushing', () => {
     assert.match(backmergeWorkflow, /name:\s*Back-Merge Main To Dev/);
     assert.match(backmergeWorkflow, /Setup CI environment/);
-    assert.match(backmergeWorkflow, /Install Node validation dependencies[\s\S]*npm ci --ignore-scripts/);
-    assert.match(backmergeWorkflow, /Sync main into dev/);
+    assert.match(backmergeWorkflow, /Sync main into dev[\s\S]*Install merged dev validation dependencies[\s\S]*npm ci --ignore-scripts/);
     assert.match(backmergeWorkflow, /Commit synchronized dev package[\s\S]*git add --all[\s\S]*git commit --no-verify -m "Rebuild dev package after main sync"/);
     assert.match(backmergeWorkflow, /Validate merged dev state before push/);
     assert.match(backmergeWorkflow, /Push back-merge branch when updated/);


### PR DESCRIPTION
Fixes the main-to-dev back-merge workflow failure observed in run 33083929878. The workflow now synchronizes main into dev before running npm ci, so validation uses the merged dev package-lock and dependencies such as fast-check are available. Workflow self-checks and versioning guards now enforce this ordering. No plugin runtime, package, version, or release metadata changes are included.