### PR TITLE
Add manual CodeQL recovery checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '17 6 * * 1'
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/scripts/workflow_self_check.sh
+++ b/scripts/workflow_self_check.sh
@@ -182,6 +182,9 @@ if ((codeqlWorkflow.match(/github\/codeql-action\/(?:init|autobuild|analyze)@[0-
 if (!/node scripts\/codeql_alert_guard\.mjs --commit-sha/.test(codeqlWorkflow)) {
   fail('CodeQL must enforce zero open alerts for the analyzed commit.');
 }
+if (!/schedule:/.test(codeqlWorkflow) || !/workflow_dispatch:/.test(codeqlWorkflow)) {
+  fail('CodeQL must run on schedule and support manual recovery checks.');
+}
 if (!/actions\/dependency-review-action@[0-9a-f]{40}\s+# v5/.test(dependencyReviewWorkflow)
     || !/fail-on-severity:\s*high/.test(dependencyReviewWorkflow)
     || !/license-check:\s*true/.test(dependencyReviewWorkflow)

--- a/tests/scheduled-workflow-health.test.mjs
+++ b/tests/scheduled-workflow-health.test.mjs
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {
     SCHEDULED_WORKFLOW_TARGETS,
@@ -8,6 +10,7 @@ import {
 
 const target = SCHEDULED_WORKFLOW_TARGETS[0];
 const nowMs = Date.parse('2026-08-10T12:00:00Z');
+const root = path.resolve(process.cwd());
 
 const run = ({ event = 'schedule', status = 'completed', conclusion = 'success', createdAt, updatedAt = createdAt } = {}) => ({
     event,
@@ -37,6 +40,13 @@ test('scheduled workflow health accepts a manual proof run until the daily-monit
     });
     assert.equal(result.healthy, true);
     assert.equal(result.latestSuccess.event, 'workflow_dispatch');
+});
+
+test('every monitored workflow supports a manual proof run', () => {
+    for (const { workflowFile } of SCHEDULED_WORKFLOW_TARGETS) {
+        const workflow = fs.readFileSync(path.join(root, '.github', 'workflows', workflowFile), 'utf8');
+        assert.match(workflow, /^\s{2}workflow_dispatch:\s*$/m, workflowFile);
+    }
 });
 
 test('scheduled workflow health identifies the daily Unraid compatibility monitor', () => {

--- a/tests/security-release-contract.test.mjs
+++ b/tests/security-release-contract.test.mjs
@@ -13,6 +13,7 @@ test('CodeQL scans dev and main for pushes and pull requests', () => {
     const workflow = read('.github/workflows/codeql.yml');
     assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*- dev\s*\n\s*- main/);
     assert.match(workflow, /pull_request:\s*\n\s*branches:\s*\n\s*- dev\s*\n\s*- main/);
+    assert.match(workflow, /workflow_dispatch:/);
     assert.match(workflow, /queries: security-extended,security-and-quality/);
     assert.equal((workflow.match(/github\/codeql-action\/(?:init|autobuild|analyze)@[0-9a-f]{40}\s+# v4/g) || []).length, 3);
 });


### PR DESCRIPTION
## Summary
- add a manual CodeQL recovery trigger
- ensure every workflow monitored by the scheduled-health watchdog supports manual dispatch
- add workflow contract coverage

## Validation
- 
ode --test tests/scheduled-workflow-health.test.mjs tests/security-release-contract.test.mjs tests/versioning-guard.test.mjs
- ash scripts/workflow_self_check.sh
- ash scripts/run_ci_suite.sh --lane workflow-guards
- ash scripts/run_ci_suite.sh --lane lint --lane tests

Workflow-only maintenance; no plugin package or version change.