### PR TITLE
Refresh OpenSSF Scorecard findings

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,6 +2,9 @@ name: OpenSSF Scorecard
 
 on:
   branch_protection_rule:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '29 7 * * 2'
   workflow_dispatch:

--- a/docs/codeql-triage.md
+++ b/docs/codeql-triage.md
@@ -28,8 +28,9 @@ CodeQL Action v4 runs for pushes and pull requests targeting both `dev` and
 no new high-or-higher security findings before a protected branch can be merged.
 Dependency Review separately rejects pull requests that introduce high-or-critical
 known vulnerabilities or licenses outside the repository's approved quality-tooling
-set. OpenSSF Scorecard publishes a scheduled supply-chain posture report to code
-scanning. The weekly OSV job scans the generated CycloneDX dependency inventory,
+set. OpenSSF Scorecard publishes a supply-chain posture report to code scanning
+on every `main` push and on its weekly schedule. The weekly OSV job scans the
+generated CycloneDX dependency inventory,
 uploads SARIF, and fails when it reports a known vulnerability. A scheduled-workflow
 watchdog checks that CodeQL, Scorecard, and OSV continue producing timely successful
 runs and maintains one recovery issue if they do not. Code-quality findings remain

--- a/scripts/workflow_self_check.sh
+++ b/scripts/workflow_self_check.sh
@@ -209,6 +209,7 @@ if (!/actions\/dependency-review-action@[0-9a-f]{40}\s+# v5/.test(dependencyRevi
 }
 if (!/ossf\/scorecard-action@[0-9a-f]{40}\s+# v2\.4\.4/.test(scorecardWorkflow)
     || !/github\/codeql-action\/upload-sarif@[0-9a-f]{40}\s+# v4/.test(scorecardWorkflow)
+    || !/push:\s*\n\s*branches:\s*\n\s*- main/.test(scorecardWorkflow)
     || !/publish_results:\s*true/.test(scorecardWorkflow)
     || !/security-events:\s*write/.test(scorecardWorkflow)
     || !/id-token:\s*write/.test(scorecardWorkflow)) {

--- a/tests/helpers/fast-check.js
+++ b/tests/helpers/fast-check.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// Keep the property-test dependency in a .js module so OpenSSF Scorecard can
+// recognize the same fast-check harness that the Node test suite executes.
+module.exports = require('fast-check');

--- a/tests/security-property-fuzz.test.mjs
+++ b/tests/security-property-fuzz.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import fc from 'fast-check';
+import fc from './helpers/fast-check.js';
 import {
     compareSanitizedSupportBundles,
     renderSupportBundleComparisonMarkdown

--- a/tests/security-release-contract.test.mjs
+++ b/tests/security-release-contract.test.mjs
@@ -74,8 +74,9 @@ test('dependency review blocks vulnerable or unapproved dependency changes', () 
     assert.match(workflow, /warn-only: false/);
 });
 
-test('OpenSSF Scorecard publishes pinned SARIF results on a schedule', () => {
+test('OpenSSF Scorecard refreshes main findings and publishes pinned SARIF results', () => {
     const workflow = read('.github/workflows/scorecard.yml');
+    assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*- main/);
     assert.match(workflow, /schedule:/);
     assert.match(workflow, /workflow_dispatch:/);
     assert.match(workflow, /ossf\/scorecard-action@[0-9a-f]{40}\s+# v2\.4\.4/);
@@ -83,6 +84,14 @@ test('OpenSSF Scorecard publishes pinned SARIF results on a schedule', () => {
     assert.match(workflow, /publish_results: true/);
     assert.match(workflow, /security-events: write/);
     assert.match(workflow, /id-token: write/);
+});
+
+test('OpenSSF Scorecard can detect the fast-check property-test harness', () => {
+    const adapter = read('tests/helpers/fast-check.js');
+    const suite = read('tests/security-property-fuzz.test.mjs');
+    assert.match(adapter, /require\(['"]fast-check['"]\)/);
+    assert.match(suite, /from ['"]\.\/helpers\/fast-check\.js['"]/);
+    assert.match(suite, /fc\.assert\(fc\.property\(/);
 });
 
 test('workflows never upload live Unraid browser evidence', () => {


### PR DESCRIPTION
## Summary

- make the existing `fast-check` security property suite detectable by OpenSSF Scorecard
- refresh Scorecard findings on every `main` push as well as weekly
- update workflow contracts and security-monitoring documentation

## Release impact

This is a workflow, test, and documentation maintenance change only. It does not change the plugin manifest, package archives, version, or stable release assets, so `Release On Main` will skip release publication.

## Validation

- full lint, test, workflow-test, workflow-guard, and docs-guard lanes passed
- OpenSSF Scorecard v5.5.0 detected the local fuzzing integration at 10/10
- release guard and install smoke passed for existing stable version 2026.08.28.05